### PR TITLE
Check if a request includes the Host header before forcing SSL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ function createServer (opts, handler) {
     fileServer.serve(req, res, function () {
       // If we served our ACME challenge then we don't need to continue.
       if (res.headersSent) return
-      if (opts.forceSSL) {
+      if (opts.forceSSL && req.headers.host) {
         // Automatically ensure that each request is handled with https.
         var host = req.headers.host.split(':')[0] + ':' + ports.https
         res.writeHead(302, { 'Location': 'https://' + host + req.url })


### PR DESCRIPTION
The missing Host header causes a crash when trying to call split on it.

```bash
TypeError: Cannot read property 'split' of undefined
    at /xxxxx/node_modules/auto-sni/lib/index.js:98:36
    at Server.finish (/xxxxx/node_modules/node-static/lib/node-static.js:111:13)
    at finish (/xxxxx/node_modules/node-static/lib/node-static.js:170:14)
    at /xxxxx/node_modules/node-static/lib/node-static.js:144:17
    at wrappedCallback (/xxxxx/node_modules/newrelic/lib/transaction/tracer/index.js:291:17)
    at wrapped (/xxxxx/node_modules/newrelic/lib/transaction/tracer/index.js:155:28)
    at wrappedCallback (/xxxxx/node_modules/newrelic/lib/transaction/tracer/index.js:417:66)
    at wrapped (/xxxxx/node_modules/newrelic/lib/transaction/tracer/index.js:155:28)
    at FSReqWrap.oncomplete (fs.js:82:15)
```