### PR TITLE
Fix to use path join correctly

### DIFF
--- a/lib/load.js
+++ b/lib/load.js
@@ -41,7 +41,8 @@ function load (domains, opts) {
   // Lock to ensure we are not fetching a host multiple times.
   if (lock[hostname]) return lock[hostname]
   var stdio = opts.debug ? 'pipe' : 'ignore'
-  var configDir = path.join(process.env.HOME ? process.env.HOME : process.env.USERPROFILE, '/letsencrypt/etc')
+  var homedir = (process.platform === 'win32') ? process.env.HOMEPATH : process.env.HOME;
+  var configDir = path.join(homedir, 'letsencrypt','etc')
   var liveDir = path.join(configDir, 'live', hostname)
   var liveOptsDir = path.join(liveDir, 'opts.json')
   var logsDir = path.join(configDir, 'letsencrypt.logs')


### PR DESCRIPTION
1. Doesn't address later Windows OS issues do to exec and linux specific commands. Not sure I'm going to take refactoring that on by myself. Do you want to corroborate on that?
2. Should think about using `path.join(__dirname,'../','letsencrypt','etc')`instead as this would keep different local node apps using auto-sni from corrupting each other.